### PR TITLE
Fix html not closed becouse of gtm and displace gtm noscript

### DIFF
--- a/ckanext/alisea/templates/base.html
+++ b/ckanext/alisea/templates/base.html
@@ -18,10 +18,3 @@
         {% include 'snippets/gtm.html' %}
     {% endblock %}
 {% endblock %}
-
-{% block bodytag %}
-  {{ super() }}
-    {% block gtm %}
-        {% include 'snippets/gtm_noscript.html' %}
-    {% endblock %}
-{% endblock %}

--- a/ckanext/alisea/templates/page.html
+++ b/ckanext/alisea/templates/page.html
@@ -157,6 +157,7 @@
   #}
   {%- block footer %}
     {% include "footer.html" %}
+    {% include 'snippets/gtm_noscript.html' %}
   {% endblock -%}
 {%- endblock -%}
 


### PR DESCRIPTION
- Fix not closed html tag bug that we have becouse of the placement of the Google Tag manager in the html body
- Displace noscript Google Tag manager to footer section